### PR TITLE
Re-label submit button on login page to 'Log in'

### DIFF
--- a/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/messages/messages_en.properties
+++ b/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/messages/messages_en.properties
@@ -1,4 +1,4 @@
-doLogIn=Continue
+doLogIn=Log in
 doForgotPassword=Forgot your password?
 
 registerLink=Create an account


### PR DESCRIPTION
Re-labels the submit button on the login page as 'Log in' from
'Continue'. As the login page is not usually just a step in a journey
but rather a single page form with logging in as the action.

Original:
![kc-govuk-master-2017-05-10](https://cloud.githubusercontent.com/assets/10604229/25909493/3cccf7b8-35a5-11e7-9ea9-f3bf03fdc869.png)

Proposed:
![kc-govuk-login-submit-button](https://cloud.githubusercontent.com/assets/10604229/25909498/421f49a0-35a5-11e7-88b3-ba5f0661638d.png)
