### PR TITLE
Remove PROXY_ADDRESS_FORWARDING from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ keycloak:
     MYSQL_PORT_3306_TCP_PORT: "3306"
     WAIT_ON_ADDR: "mariadb"
     WAIT_ON_PORT: "3306"
-    PROXY_ADDRESS_FORWARDING: "true"
   command:
   - -b 0.0.0.0 --server-config=standalone.xml
 


### PR DESCRIPTION
Removes PROXY_ADDRESS_FORWARDING from the Keycloak settings in
docker-compose as we do not need it, even on Macs.