### PR TITLE
Add styling to social providers

### DIFF
--- a/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/login.ftl
+++ b/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/login.ftl
@@ -67,11 +67,12 @@
         </#if>
 
         <#if realm.password && social.providers??>
-            <#-- This section of the theme has not yet been styled. Non-trivial user research, interaction design and content design work is required to develop a solution for login using 3rd-party identity providers. -->
+            <#-- This section of the theme has not yet been well styled. Non-trivial user research, interaction design and content design work is required to develop a solution for login using 3rd-party identity providers. -->
             <div id="kc-social-providers">
-                <ul>
+                <h2 class="heading-medium">${msg("socialProviders")}</h2>
+                <ul class="list">
                     <#list social.providers as p>
-                        <li><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span class="text">${p.displayName}</span></a></li>
+                        <li><a href="${p.loginUrl}" id="zocial-${p.alias}" class="button zocial ${p.providerId}">${p.displayName}</a></li>
                     </#list>
                 </ul>
             </div>

--- a/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/messages/messages_en.properties
+++ b/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/messages/messages_en.properties
@@ -29,3 +29,5 @@ errorTitle=There was a problem
 errorTitleHtml=There was a problem
 email=Email address
 doResetPassword=Send email
+
+socialProviders=Sign in with...

--- a/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/template.ftl
+++ b/themes/2.5.4_0.19.2_2.2.1/govuk_0.19.2_2.2.1/login/template.ftl
@@ -186,19 +186,20 @@
                                     </div>
                                 </div>
 
-                                <#if displayInfo>
-                                    <div id="kc-info" class="${properties.kcInfoAreaClass!}">
-                                        <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
-                                            <#nested "info">
-                                        </div>
-                                    </div>
-                                </#if>
                             </div>
                         </div>
                     </div>
                 </div>
+            </div>
 
-
+            <div class="column-one-third">
+                <#if displayInfo>
+                    <div id="kc-info" class="${properties.kcInfoAreaClass!}">
+                        <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
+                            <#nested "info">
+                        </div>
+                    </div>
+                </#if>
             </div>
         </div>
     </main>


### PR DESCRIPTION
Adds a very basic first iteration of styling to the 'social providers'.
The providers are simply represented as buttons.

Original => Proposed
![social-providers-original-small](https://cloud.githubusercontent.com/assets/10604229/25969664/aea73518-368d-11e7-96e3-3fa4f5dad572.png) ![social-providers-proposal-small](https://cloud.githubusercontent.com/assets/10604229/25969669/b9b4404a-368d-11e7-9079-17d283b51237.png)

Original (large):
![social-providers-original-large](https://cloud.githubusercontent.com/assets/10604229/25969743/fdcc4336-368d-11e7-8163-1457ac04ca42.png)

Proposed (large):
![social-providers-proposal-large](https://cloud.githubusercontent.com/assets/10604229/25969760/06b83bd0-368e-11e7-902b-f51c3fe032c8.png)

It's no work of art but I think it's better than nothing.