### PR TITLE
Typo fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:sass:govuk_elements-ie6": "npm-sass sass/govuk_elements-ie6.scss > govuk/login/resources/css/govuk_elements-ie6.css",
     "build:sass:govuk_elements-ie7": "npm-sass sass/govuk_elements-ie6.scss > govuk/login/resources/css/govuk_elements-ie7.css",
     "build:sass:govuk_elements-ie8": "npm-sass sass/govuk_elements-ie6.scss > govuk/login/resources/css/govuk_elements-ie8.css",
-    "dist": "npm-run-all dist:govuk dist:govuk-social-provider-login",
+    "dist": "npm-run-all dist:govuk dist:govuk-social-providers-only",
     "dist:govuk": "tar -czf govuk.tar.gz govuk/",
     "dist:govuk-social-providers-only": "tar -czf govuk-social-providers-only.tar.gz govuk-social-providers-only/",
     "clean": "rm -rf govuk/login/resources/ && rm govuk.tar.gz"


### PR DESCRIPTION
Fixed a typo in `package.json` and ignored the new theme tarball.