### PR TITLE
Bump version to reflect breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keycloak-theme-govuk",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "devDependencies": {
     "govuk-elements-sass": "2.2.1",
     "govuk_template_jinja": "0.19.2",


### PR DESCRIPTION
Bumps the version to 1.0.0 to reflect the breaking change made to the standard `govuk` theme. - Those who want the old style theme should switch to `govuk-internal`.