### PR TITLE
Partial Grant Fix

### DIFF
--- a/govuk/login/login-oauth-grant.ftl
+++ b/govuk/login/login-oauth-grant.ftl
@@ -1,12 +1,14 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout bodyClass="oauth"; section>
     <#if section = "title">
-        ${msg("oauthGrantTitle")}
+        <#if client.name?has_content>
+            ${msg("oauthGrantTitle",advancedMsg(client.name))}
+        <#else>
+            ${msg("oauthGrantTitle",client.clientId)}
+        </#if>
     <#elseif section = "form">
-        ${msg("oauthGrantTitleHtml",(realm.displayName!''))?no_esc} <strong><#if client.name??>${advancedMsg(client.name)}<#else>${client.clientId}</#if></strong>.
-
         <div id="kc-oauth" class="content-area">
-            <h2 class="heading-medium">${msg("oauthGrantRequest")}</h3>
+            <h2 class="heading-medium">${msg("oauthGrantRequest")}</h2>
             <ul class="list list-bullet">
                 <#if oauth.claimsRequested??>
                     <li>


### PR DESCRIPTION
- removing the empty holder from the consent form
- note: i can't find the methods for client, realm and claim requests in the bean anymore https://www.keycloak.org/docs-api/4.1/javadocs/org/keycloak/forms/login/freemarker/model/OAuthGrantBean.html