### PR TITLE
COP Theme: Swap columns

### DIFF
--- a/govuk-cop/login/template.ftl
+++ b/govuk-cop/login/template.ftl
@@ -129,6 +129,15 @@
         <div><#nested "back"></div>
 
         <div class="grid-row">
+            <div class="column-one-third">
+                <#if displayInfo>
+                    <div id="kc-info" class="${properties.kcInfoAreaClass!}">
+                        <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
+                            <#nested "info">
+                        </div>
+                    </div>
+                </#if>
+            </div>
             <div class="column-two-thirds">
                 <h1 class="heading-large"><#nested "title"></h1>
 
@@ -195,16 +204,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
-
-            <div class="column-one-third">
-                <#if displayInfo>
-                    <div id="kc-info" class="${properties.kcInfoAreaClass!}">
-                        <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
-                            <#nested "info">
-                        </div>
-                    </div>
-                </#if>
             </div>
         </div>
     </main>


### PR DESCRIPTION
This commit places buttons for this theme on the left in desktop (and above on mobile) and input fields on right on desktop (and below on mobile).

I'd be grateful if you could let me know ASAP how soon you might be able to merge and deploy this, because some of our users are mistakenly filling the text fields instead of pressing the buttons and this is causing issues. Many thanks.