### PR TITLE
Add list of OTP applications to template

### DIFF
--- a/govuk/login/login-config-totp.ftl
+++ b/govuk/login/login-config-totp.ftl
@@ -8,28 +8,34 @@
 <ol id="kc-totp-settings" class="list list-number">
     <li>
         <p>${msg("loginTotpStep1")}</p>
-        </li>
+
+        <ul class="list list-bullet">
+            <#list totp.policy.supportedApplications as app>
+                <li>${app}</li>
+            </#list>
+        </ul>
+    </li>
     <li>
         <p>${msg("loginTotpStep2")}</p>
         <img id="kc-totp-secret-qr-code" src="data:image/png;base64, ${totp.totpSecretQrCode}" alt="Figure: Barcode"><br/>
         <span class="code">${totp.totpSecretEncoded}</span>
-        </li>
+    </li>
     <li>
         <p>${msg("loginTotpStep3")}</p>
-        </li>
-    </ol>
-    <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-totp-settings-form" method="post">
-        <div class="${properties.kcFormGroupClass!}">
-            <div class="${properties.kcLabelWrapperClass!}">
-                <label for="totp" class="${properties.kcLabelClass!}">${msg("loginTotpOneTime")}</label>
-            </div>
-            <div class="${properties.kcInputWrapperClass!}">
-                <input type="text" id="totp" name="totp" autocomplete="off" class="${properties.kcInputClass!}" />
-            </div>
-            <input type="hidden" id="totpSecret" name="totpSecret" value="${totp.totpSecret}" />
+    </li>
+</ol>
+<form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-totp-settings-form" method="post">
+    <div class="${properties.kcFormGroupClass!}">
+        <div class="${properties.kcLabelWrapperClass!}">
+            <label for="totp" class="${properties.kcLabelClass!}">${msg("loginOtpOneTime")}</label>
         </div>
+        <div class="${properties.kcInputWrapperClass!}">
+            <input type="text" id="totp" name="totp" autocomplete="off" class="${properties.kcInputClass!}" />
+        </div>
+        <input type="hidden" id="totpSecret" name="totpSecret" value="${totp.totpSecret}" />
+    </div>
 
-        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
-    </form>
+    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+</form>
     </#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
Resolves #27 

This PR:

- Adds the list of supported OTP applications to the govuk theme template
- Corrects the field label for the "One-time code" in step 3

![image](https://user-images.githubusercontent.com/1932948/137278613-f43d5125-126f-4bc1-8d84-063373da6941.png)
