### PR TITLE
OTP fix for CBA and update docker-compose to keycloak v22

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ To bring up the server, make sure you’ve installed and started [Docker Communi
 ```bash
 $ npm install
 $ npm run build
+# Run command for Keycloak v22, or...
 $ docker-compose up
+# Run command for Keycloak v15
+$ docker-compose -f docker-compose-v15.yml up
 ```
 The Keycloak server will now be available on <http://localhost:8080>. You can log into the Administration Console using “**admin**” as both username and password.
 
@@ -70,7 +73,7 @@ To set up the local Keycloak server to send e-mails to MailDev:
 
     - Host: **maildev**
 
-    - From: **keycloak@keycloak**
+    - From: **keycloak@keycloak.com**
 
 4. Click on “Save”
 

--- a/docker-compose-v15.yml
+++ b/docker-compose-v15.yml
@@ -1,0 +1,50 @@
+services:
+  mariadb:
+    container_name: mariadb
+    image: mariadb:10.4.8
+    ports:
+    - "3306"
+    environment:
+      MYSQL_DATABASE: "keycloak"
+      MYSQL_PASSWORD: "password"
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_USER: "keycloak"
+
+  keycloak:
+    container_name: keycloak
+    image: quay.io/ukhomeofficedigital/keycloak:v15.0.2
+    ports:
+    - "8080:8080"
+    links:
+    - mariadb
+    - maildev
+    volumes:
+    - ./.docker-compose/keycloak.env:/etc/secrets/keycloak.env
+    - ./govuk/:/opt/jboss/keycloak/themes/govuk/
+    - ./govuk-internal/:/opt/jboss/keycloak/themes/govuk-internal/
+    - ./govuk-internal-cba/:/opt/jboss/keycloak/themes/govuk-internal-cba/
+    - ./govuk-internal-dq/:/opt/jboss/keycloak/themes/govuk-internal-dq/
+    - ./govuk-cop/:/opt/jboss/keycloak/themes/govuk-cop/
+    - ./hmpo-lev/:/opt/jboss/keycloak/themes/hmpo-lev/
+    - ./govuk-social-providers/:/opt/jboss/keycloak/themes/govuk-social-providers/
+    - ./govuk-drt/:/opt/jboss/keycloak/themes/govuk-drt/
+    - ./govuk-rscas/:/opt/jboss/keycloak/themes/govuk-rscas/
+    environment:
+      DB_VENDOR: "mariadb"
+      MARIADB_PORT: "3306"
+      KEYCLOAK_ENVIRONMENT: "/etc/secrets/keycloak.env"
+      KEYCLOAK_PASSWORD: "admin"
+      KEYCLOAK_USER: "admin"
+      MYSQL_PORT_3306_TCP_ADDR: "mariadb"
+      MYSQL_PORT_3306_TCP_PORT: "3306"
+      WAIT_ON_ADDR: "mariadb"
+      WAIT_ON_PORT: "3306"
+    command:
+    - -b 0.0.0.0 --server-config=standalone.xml
+
+  maildev:
+    container_name: maildev
+    image: djfarrelly/maildev:1.1.0
+    ports:
+    - "8081:80"
+    - "25"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: mariadb
     image: mariadb:10.4.8
     ports:
-    - "3306"
+      - "3306"
     environment:
       MYSQL_DATABASE: "keycloak"
       MYSQL_PASSWORD: "password"
@@ -12,39 +12,36 @@ services:
 
   keycloak:
     container_name: keycloak
-    image: quay.io/ukhomeofficedigital/keycloak:v15.0.2
+    image: quay.io/keycloak/keycloak:22.0.5
     ports:
-    - "8080:8080"
-    links:
-    - mariadb
-    - maildev
-    volumes:
-    - ./.docker-compose/keycloak.env:/etc/secrets/keycloak.env
-    - ./govuk/:/opt/jboss/keycloak/themes/govuk/
-    - ./govuk-internal/:/opt/jboss/keycloak/themes/govuk-internal/
-    - ./govuk-internal-cba/:/opt/jboss/keycloak/themes/govuk-internal-cba/
-    - ./govuk-internal-dq/:/opt/jboss/keycloak/themes/govuk-internal-dq/
-    - ./govuk-cop/:/opt/jboss/keycloak/themes/govuk-cop/
-    - ./hmpo-lev/:/opt/jboss/keycloak/themes/hmpo-lev/
-    - ./govuk-social-providers/:/opt/jboss/keycloak/themes/govuk-social-providers/
-    - ./govuk-drt/:/opt/jboss/keycloak/themes/govuk-drt/
-    - ./govuk-rscas/:/opt/jboss/keycloak/themes/govuk-rscas/
+      - "8080:8080"
     environment:
-      DB_VENDOR: "mariadb"
-      MARIADB_PORT: "3306"
-      KEYCLOAK_ENVIRONMENT: "/etc/secrets/keycloak.env"
-      KEYCLOAK_PASSWORD: "admin"
-      KEYCLOAK_USER: "admin"
-      MYSQL_PORT_3306_TCP_ADDR: "mariadb"
-      MYSQL_PORT_3306_TCP_PORT: "3306"
-      WAIT_ON_ADDR: "mariadb"
-      WAIT_ON_PORT: "3306"
-    command:
-    - -b 0.0.0.0 --server-config=standalone.xml
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB: mariadb
+      KC_DB_URL_HOST: mariadb
+      KC_DB_URL_PORT: 3306
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: password
+    volumes:
+      - ./.docker-compose/keycloak.env:/etc/secrets/keycloak.env
+      - ./govuk/:/opt/keycloak/themes/govuk/
+      - ./govuk-internal/:/opt/keycloak/themes/govuk-internal/
+      - ./govuk-internal-cba/:/opt/keycloak/themes/govuk-internal-cba/
+      - ./govuk-internal-dq/:/opt/keycloak/themes/govuk-internal-dq/
+      - ./govuk-cop/:/opt/keycloak/themes/govuk-cop/
+      - ./hmpo-lev/:/opt/keycloak/themes/hmpo-lev/
+      - ./govuk-social-providers/:/opt/keycloak/themes/govuk-social-providers/
+      - ./govuk-drt/:/opt/keycloak/themes/govuk-drt/
+      - ./govuk-rscas/:/opt/keycloak/themes/govuk-rscas/
+    command: start-dev
+    depends_on:
+      - mariadb
+      - maildev
 
   maildev:
     container_name: maildev
     image: djfarrelly/maildev:1.1.0
     ports:
-    - "8081:80"
-    - "25"
+      - "8081:80"
+      - "25"

--- a/govuk-internal-cba/login/messages/messages_en.properties
+++ b/govuk-internal-cba/login/messages/messages_en.properties
@@ -1,3 +1,4 @@
 usernameOrEmail=POISE Email
 email=POISE Email
 password=CBA Password
+loginTotpOneTime=Code from Mobile Authenticator

--- a/govuk-internal/login/login-config-totp.ftl
+++ b/govuk-internal/login/login-config-totp.ftl
@@ -1,0 +1,35 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true; section>
+    <#if section = "title">
+        ${msg("loginTotpTitle")}
+    <#elseif section = "header">
+        ${msg("loginTotpTitle")}
+    <#elseif section = "form">
+<ol id="kc-totp-settings" class="list list-number">
+    <li>
+        <p>${msg("loginTotpStep1")}</p>
+        </li>
+    <li>
+        <p>${msg("loginTotpStep2")}</p>
+        <img id="kc-totp-secret-qr-code" src="data:image/png;base64, ${totp.totpSecretQrCode}" alt="Figure: Barcode"><br/>
+        <span class="code">${totp.totpSecretEncoded}</span>
+        </li>
+    <li>
+        <p>${msg("loginTotpStep3")}</p>
+        </li>
+    </ol>
+    <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-totp-settings-form" method="post">
+        <div class="${properties.kcFormGroupClass!}">
+            <div class="${properties.kcLabelWrapperClass!}">
+                <label for="totp" class="${properties.kcLabelClass!}">${msg("loginTotpOneTime")}</label>
+            </div>
+            <div class="${properties.kcInputWrapperClass!}">
+                <input type="text" id="totp" name="totp" autocomplete="off" class="${properties.kcInputClass!}" />
+            </div>
+            <input type="hidden" id="totpSecret" name="totpSecret" value="${totp.totpSecret}" />
+        </div>
+
+        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+    </form>
+    </#if>
+</@layout.registrationLayout>

--- a/govuk-internal/login/login-otp.ftl
+++ b/govuk-internal/login/login-otp.ftl
@@ -1,0 +1,71 @@
+<#import "template.ftl" as layout>
+    <@layout.registrationLayout; section>
+        <#if section="header">
+            ${msg("doLogIn")}
+            <#elseif section="form">
+                <form id="kc-otp-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}"
+                    method="post">
+                    <#if otpLogin.userOtpCredentials?size gt 1>
+                        <div class="${properties.kcFormGroupClass!}">
+                            <div class="${properties.kcInputWrapperClass!}">
+                                <#list otpLogin.userOtpCredentials as otpCredential>
+                                    <div class="${properties.kcSelectOTPListClass!}">
+                                    <input type="hidden" value="${otpCredential.id}">
+                                        <div class="${properties.kcSelectOTPListItemClass!}">
+                                            <span class="${properties.kcAuthenticatorOtpCircleClass!}"></span>
+                                            <h2 class="${properties.kcSelectOTPItemHeadingClass!}">
+                                                ${otpCredential.userLabel}
+                                            </h2>
+                                        </div>
+                                    </div>
+                                </#list>
+                            </div>
+                        </div>
+                    </#if>
+
+                    <div class="${properties.kcFormGroupClass!}">
+                        <div class="${properties.kcLabelWrapperClass!}">
+                            <label for="otp" class="${properties.kcLabelClass!}">${msg("loginOtpOneTime")}</label>
+                        </div>
+                        <p>The one-time code is available in the FreeOTP Authenticator application, which you downloaded to your mobile phone when you set up this account</p>
+
+                        <div class="${properties.kcInputWrapperClass!}">
+                            <input id="otp" name="otp" autocomplete="off" type="text" class="${properties.kcInputClass!}"
+                            autofocus/>
+                        </div>
+                    </div>
+
+                    <div class="${properties.kcFormGroupClass!}">
+                        <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                            <div class="${properties.kcFormOptionsWrapperClass!}">
+                            </div>
+                        </div>
+
+                        <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                            <input
+                                class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                                name="login" id="kc-login" type="submit" value="${msg("doLogIn")}" />
+                        </div>
+                    </div>
+                </form>
+            <script type="text/javascript" src="${url.resourcesCommonPath}/node_modules/jquery/dist/jquery.min.js"></script>
+            <script type="text/javascript">
+            $(document).ready(function() {
+                // Card Single Select
+                $('.card-pf-view-single-select').click(function() {
+                  if ($(this).hasClass('active'))
+                  { $(this).removeClass('active'); $(this).children().removeAttr('name'); }
+                  else
+                  { $('.card-pf-view-single-select').removeClass('active');
+                  $('.card-pf-view-single-select').children().removeAttr('name');
+                  $(this).addClass('active'); $(this).children().attr('name', 'selectedCredentialId'); }
+                });
+
+                var defaultCred = $('.card-pf-view-single-select')[0];
+                if (defaultCred) {
+                    defaultCred.click();
+                }
+              });
+            </script>
+        </#if>
+    </@layout.registrationLayout>

--- a/govuk-internal/login/login-verify-email.ftl
+++ b/govuk-internal/login/login-verify-email.ftl
@@ -1,0 +1,16 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true; section>
+    <#if section = "title">
+        ${msg("emailVerifyTitle")}
+    <#elseif section = "header">
+        ${msg("emailVerifyTitle")}    
+    <#elseif section = "form">
+        <p class="instruction">${msg("emailVerifyInstruction1")}</p>
+        <p class="instruction">
+            ${msg("emailVerifyInstruction2")}            
+            ${msg("emailVerifyInstruction3")} <a href="${url.loginAction}">${msg("emailResentClickMessage")}</a> 
+        </p>
+    <#elseif section = "info">
+       
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
The changes within this PR relate to an issue with OTP not working on Keycloak v22. Prior to this change, when a user is instructed to 'Configure OTP', this causes a server error.

## Changes
- Upgraded the version of Keycloak from v15 to v22 on the docker-compose.yml file, whilst still maintaining a v15 version of the docker compose file (docker-compose-v15.yml). The README has been updated accordingly.
- Added three OTP templates to the govuk-internal theme. `login-config-totp.ftl`, `login-otp.ftl`, and also `login-verify-email.ftl`.

## Evidence of Testing
1. The docker-compose command is successful, and v22 Keycloak is started without errors.
![Screenshot 2025-07-07 at 14 05 15](https://github.com/user-attachments/assets/67500b57-575d-4245-849f-8560bd3358e6)
2. Maildev server still working with Keycloak v22.
![Screenshot 2025-07-07 at 14 07 18](https://github.com/user-attachments/assets/5daaa147-15c6-4a03-b187-f3dfe730b363)
3. The OTP configuration screen is appearing successfully.
![Screenshot 2025-07-07 at 14 09 15](https://github.com/user-attachments/assets/c859b4b9-b9e3-41ee-ba97-f9e0f58b0341)

