### PR TITLE
DRTII-673 remove incorrect tabindex attributes

### DIFF
--- a/govuk-drt/login/login.ftl
+++ b/govuk-drt/login/login.ftl
@@ -38,18 +38,18 @@
                                        autocomplete="off"/>
                             </div>
                         </div>
-                        
+
                         <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
                             <#if realm.rememberMe && !usernameEditDisabled??>
                                 <div class="checkbox ${properties.kcFormGroupClass}">
                                     <div class="multiple-choice">
                                         <#if login.rememberMe??>
-                                            <input id="rememberMe" name="rememberMe" type="checkbox" tabindex="3"
+                                            <input id="rememberMe" name="rememberMe" type="checkbox"
                                                    checked>
                                             <label for="rememberMe"
                                                    class="${properties.kcCheckboxLabelClass}">${msg("rememberMe")}</label>
                                         <#else>
-                                            <input id="rememberMe" name="rememberMe" type="checkbox" tabindex="3">
+                                            <input id="rememberMe" name="rememberMe" type="checkbox">
                                             <label for="rememberMe"
                                                    class="${properties.kcCheckboxLabelClass}">${msg("rememberMe")}</label>
                                         </#if>


### PR DESCRIPTION
The tab order of the signin page is illogical due to the tabindex on the checkbox element using a tabindex with a value of 3. This means that users using the tab command will have to tab through the entire page before encountering the checkbox.

This fails WCAG 2.2 success critria 2.4.3 (Focus Order, Level A).

This PR removes the tabindex to fix the tab order