### PR TITLE
Bump version of npm-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "govuk_template_jinja": "0.22.1",
     "govuk-elements-sass": "3.1.0",
     "npm-run-all": "^4.0.2",
-    "npm-sass": "^2.2.1"
+    "npm-sass": "^3.1.0"
   },
   "scripts": {
     "build": "npm-run-all build:assets build:sass",


### PR DESCRIPTION
The old version of npm-sass required a version of node-gyp which in turn required Python 2, which was sunset on 1 January 2020. As such, I wasn't able to build this codebase without Python 2 installed on my system.

This bumps npm-sass to a later version which allows me to use Python 3 to build the code.

This does mean that the underlying SASS compiler has also changed from the legacy node-sass a supported package (called simply 'sass'). This means that we're compliling the CSS differently, but those changes seem to be restricted to whitespace (so they are slightly smaller than they were previously).