### PR TITLE
Fixed govuk theme, broken due to v22 upgrade

### DIFF
--- a/govuk/login/login-config-totp.ftl
+++ b/govuk/login/login-config-totp.ftl
@@ -8,6 +8,12 @@
 <ol id="kc-totp-settings" class="list list-number">
     <li>
         <p>${msg("loginTotpStep1")}</p>
+
+        <ul class="list list-bullet">
+            <#list totp.supportedApplications as app>
+                <li>${msg(app)}</li>
+            </#list>
+        </ul>
     </li>
     <li>
         <p>${msg("loginTotpStep2")}</p>

--- a/govuk/login/login-config-totp.ftl
+++ b/govuk/login/login-config-totp.ftl
@@ -8,12 +8,6 @@
 <ol id="kc-totp-settings" class="list list-number">
     <li>
         <p>${msg("loginTotpStep1")}</p>
-
-        <ul class="list list-bullet">
-            <#list totp.policy.supportedApplications as app>
-                <li>${app}</li>
-            </#list>
-        </ul>
     </li>
     <li>
         <p>${msg("loginTotpStep2")}</p>


### PR DESCRIPTION
totp.policy.supportedApplications option is no longer needed in v22 Keycloak as it corresponds to old Keycloak v15 default console. This change removes that, and replaces it with totp.supportedApplications to allow for totp and reset password actions to work again